### PR TITLE
ignore user agent, add command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Change the ZK_HOSTS value to point to the ZooKeeper servers you want to view in 
 
 To run simple-zookeeper-viewer, execute
 
-    $ python viewer.py
-    
-Then navigate to http://localhost:5000/zk to view the root of the ZooKeeper server. Host/port can be configured via Flask
+    $ python viewer.py [host] [port]
+
+Then navigate to http://localhost:5000/zk to view the root of the ZooKeeper server.
 
 * Click on a node to view data and metadata on that node
 * Double click on a node to view that node and its children

--- a/templates/zk.html
+++ b/templates/zk.html
@@ -77,11 +77,9 @@
       getData(path);
     };
 
-    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-      var path = '/{{ path }}';
-      getNodes(path);
-      getData(path);
-    }
+    var path = '/{{ path }}';
+    getNodes(path);
+    getData(path);
   });
 </script>
 </html>

--- a/viewer.py
+++ b/viewer.py
@@ -30,6 +30,7 @@ def teardown_request(exception):
         g.zk.stop()
         g.zk.close()
 
+@app.route('/', defaults={'path': ''})
 @app.route('/zk/', defaults={'path': ''})
 @app.route('/zk/<path:path>')
 def view(path):
@@ -76,7 +77,17 @@ def parse_data(raw_data):
         data = json.loads(raw_data)
         return data
     except:
-        return raw_data
+        return repr(raw_data)
 
 if __name__ == '__main__':
-    app.run()
+    import sys
+    host = '127.0.0.1'
+    port = 5000
+    if len(sys.argv) > 1:
+        host = sys.argv[1]
+    if len(sys.argv) > 2:
+        port = int(sys.argv[2])
+
+    app.run(host=host, port=port, debug=True)
+
+


### PR DESCRIPTION
The javascript wasn't executing on chrome, so removed the conditional.

Running from inside a VM so binding to 0.0.0.0 was needed, added
extremely simple command-line options for that.

Messy data was throwing ascii encoding errors, dump the repr of that
data for raw data instead.
