### PR TITLE
Allow setting ZK_HOSTS through env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Requirements can be installed via pip and the provided INSTALL file.
 
 #### Configuration
 
-Change the ZK_HOSTS value to point to the ZooKeeper servers you want to view in viewer.py
+The default ZooKeeper host to connect to is `127.0.0.1:2181`.
+Override the hosts string through setting the environment variable `ZK_HOSTS`
+(or editing it in `viewer.py`)
+before running the app.
 
 #### Usage
 

--- a/viewer.py
+++ b/viewer.py
@@ -1,10 +1,14 @@
 import json
+import os
 from flask import Flask, render_template, g, jsonify, request
 from kazoo.client import KazooClient
+
+
 app = Flask(__name__)
 
 # Host string of the ZooKeeper servers to connect to
-ZK_HOSTS = '127.0.0.1:2181'
+ZK_HOSTS_DEFAULT = "127.0.0.1:2181"
+ZK_HOSTS = os.environ.get("ZK_HOSTS", ZK_HOSTS_DEFAULT)
 
 # Node metadata to view
 ZNODESTAT_ATTR = [


### PR DESCRIPTION
Simple change to allow using env var `ZK_HOSTS` to set the hosts string