### PR TITLE
Display data (dict) in JSON encoding (to see data type)

### DIFF
--- a/templates/_data.html
+++ b/templates/_data.html
@@ -4,7 +4,7 @@
     {{ data }}
   {% else %}
     {% for attr in data %}
-      <div class="node-data-row data-field">{{ attr }}: {{ data[attr] }}</div>
+      <div class="node-data-row data-field">{{ attr | tojson }}: {{ data[attr] | tojson }}</div>
     {% endfor %}
   {% endif %}
 </div>


### PR DESCRIPTION
Encode data in JSON to better visualize data type

e.g. instead of :

```
DATA:
    123: foo bar
    size: 4
```
->
```
DATA:
    123: "foo bar"
    "size": 4
```